### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"express": "4.12.3",
 		"jade": "*",
 		"nib": "*",
-		"request":"2.67.0",
+		"request":"2.74.0",
 		"cheerio":"0.19.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
HackerQueue currently has a 9 vulnerable dependency paths, introducing 6 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/frankcash/HackerQueue) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependency as well.

Stay Secure,
The Snyk Team
